### PR TITLE
Update misc.py

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -240,7 +240,12 @@ def clone_env(prefix1, prefix2, verbose=True, quiet=False, index_args=None):
         if not isdir(dst_dir):
             os.makedirs(dst_dir)
         if islink(src):
-            os.symlink(os.readlink(src), dst)
+            try:
+                os.symlink(os.readlink(src), dst)
+            except:
+                import ctypes
+                kdll = ctypes.windll.LoadLibrary("kernel32.dll")
+                kdll.CreateSymbolicLinkA(src, dst, 0)
             continue
 
         try:


### PR DESCRIPTION
Attempted a clone on Windows and had an exception on 243:` os.symlink(os.readlink(src), dst)`, 

> "AttributeError: ‘module’ object has no attribute ‘symlink’"

April 2015 github entry on corresponding code suggested the fix adopted here (replace with try, except and windows code) https://github.com/gcodeforks/apptrace/issues/8

I confirm the clone on Windows worked. I cannot foresee any other issues. 
Note: First github pull request, so please let me know if I can do anything clearer/better